### PR TITLE
Add config for number of results

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,48 +1,48 @@
 'use strict';
- 
+
 const got = require('got');
 const _ = require('lodash');
 const co = require('co');
 const fs = require('fs');
 const path = require('path');
 const ncp = require("copy-paste");
- 
+
 const DESC = 'Search a Gif';
- 
+
 const query_url = 'http://api.giphy.com/v1/gifs/search?q=';
 const api_key = '&api_key=dc6zaTOxFJmzC';
- 
+
 function* queryGiphy(query, limit) {
   const query_enc = encodeURIComponent(query);
   const url = query_url + query_enc + api_key + `&limit=${limit}`;
   let result = (yield got(url)).body;
- 
+
   result = JSON.parse(result);
   if (result['data']) {
     return result['data'].map(x => x);
   }
   return null;
 }
- 
+
 module.exports = (context) => {
   const preferences = context.preferences;
   let queryLimit = preferences.get().queryLimit;
   const shell = context.shell;
- 
+
   let html = 'sdqsdsqsd';
- 
+
   function startup() {
     html = fs.readFileSync(path.join(__dirname, 'preview.html'), 'utf8');
     preferences.on('update', pref => { queryLimit = pref.queryLimit; });
   }
- 
+
   function* search(query, res) {
     const query_trim = query.trim();
     if (query_trim.length === 0)
       return;
- 
+
     const query_enc = encodeURIComponent(query);
- 
+
     if (query_enc) {
       let results = yield* queryGiphy(query_trim, queryLimit);
       results = _.reject(results, (x) => x === query_trim);
@@ -66,7 +66,7 @@ module.exports = (context) => {
       });
     }
   }
- 
+
   function execute(id, payload) {
     if (payload !== 'open')
       return;
@@ -77,12 +77,12 @@ module.exports = (context) => {
         context.toast.enqueue('Pasted to clipboard !');
     })
   }
- 
+
   function renderPreview(id, payload, render) {
     var preview = html.replace('%picture%', id);
     preview = preview.replace('%url%', id);
     render(preview);
   }
- 
+
   return { startup, search: co.wrap(search), execute, renderPreview };
 };

--- a/preferences.json
+++ b/preferences.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "queryLimit": {
+      "type": "number",
+      "title": "Limit query to",
+      "default": 25
+    }
+  }
+}


### PR DESCRIPTION
Hello,

Currently the default limit of giphy API is 25 results and the plugin limits this to 20.
This PR adds the option to configure the number of results returned by Giphy's API. It will also default to 25.

😸